### PR TITLE
Add online safe Mission Level 1, 2 and 3 Ink Tank

### DIFF
--- a/Splatoon 1/Cemu/graphicPacks/Splatoon/Mods/! Spoofers/Online-Safe Ink Tank Spoofer/patches.txt
+++ b/Splatoon 1/Cemu/graphicPacks/Splatoon/Mods/! Spoofers/Online-Safe Ink Tank Spoofer/patches.txt
@@ -3,3 +3,4 @@ moduleMatches = 0x659c782e
 
 0x0202118c = li r3, $tankspoofer
 0x02021190 = blr
+0x02689080 = b 0x02689094

--- a/Splatoon 1/Cemu/graphicPacks/Splatoon/Mods/! Spoofers/Online-Safe Ink Tank Spoofer/rules.txt
+++ b/Splatoon 1/Cemu/graphicPacks/Splatoon/Mods/! Spoofers/Online-Safe Ink Tank Spoofer/rules.txt
@@ -19,6 +19,21 @@ category = Current Ink Tank:
 $tankspoofer = 1000
 
 [Preset]
+name = Mission Level 1 Ink Tank
+category = Current Ink Tank:
+$tankspoofer = 1001
+
+[Preset]
+name = Mission Level 2 Ink Tank
+category = Current Ink Tank:
+$tankspoofer = 1002
+
+[Preset]
+name = Mission Level 3 Ink Tank
+category = Current Ink Tank:
+$tankspoofer = 1003
+
+[Preset]
 name = Rival Ink Tank
 category = Current Ink Tank:
 $tankspoofer = 2000


### PR DESCRIPTION
As the title implies, this adds Mission level 1-3 Ink Tanks. 

The Assembly line I added in patches.txt is required for them to have the same capacity as the Default Ink Tank. 